### PR TITLE
Implement AI risk engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This project provides a FastAPI-based web application for AI-driven risk analysi
    ```
 4. Open `http://localhost:57802` in your browser to see the landing page.
    From there you can launch the multi-step data collection wizard.
+   After confirming your data, the app will call OpenAI to generate a markdown
+   risk report and email it to the configured address.
 
 ## Development
 Run the app directly with uvicorn:

--- a/app/analysis.py
+++ b/app/analysis.py
@@ -1,0 +1,91 @@
+import os
+import json
+import asyncio
+import smtplib
+from email.message import EmailMessage
+
+import openai
+
+from .db import log_submission
+from models import prompts
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+MODEL = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+
+
+def _call_openai(prompt: str) -> str:
+    response = openai.ChatCompletion.create(
+        model=MODEL,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.2,
+    )
+    return response.choices[0].message.content.strip()
+
+
+async def analyze_chunk(kind: str, content: str) -> dict:
+    prompt = prompts.PROMPTS[kind].format(data=content)
+
+    def run():
+        try:
+            text = _call_openai(prompt)
+            return json.loads(text)
+        except Exception:
+            return {"score": 50, "rationale": "N/A", "next_steps": "N/A"}
+
+    return await asyncio.to_thread(run)
+
+
+async def analyze(data: dict) -> str:
+    chunks = {
+        "company": json.dumps(data.get("company", {})),
+        "context": json.dumps(data.get("context", {})),
+    }
+    if data.get("extracted_text"):
+        chunks["documents"] = data["extracted_text"][:4000]
+
+    results = {}
+    for kind, text in chunks.items():
+        results[kind] = await analyze_chunk(kind, text)
+
+    overall = sum(r["score"] for r in results.values()) / len(results)
+
+    md_lines = ["# Risk Analysis Report", f"**Overall Risk Score:** {overall:.1f}", ""]
+    name_map = {"company": "Company Info", "context": "Deal Context", "documents": "Documents"}
+    for kind, res in results.items():
+        md_lines.append(f"## {name_map.get(kind, kind.title())}")
+        md_lines.append(f"- **Score:** {res['score']}")
+        md_lines.append(f"- **Rationale:** {res['rationale']}")
+        md_lines.append(f"- **Next Steps:** {res['next_steps']}")
+        md_lines.append("")
+    md_lines.append("_This is an AI-driven risk analysis. Use in conjunction with human judgment._")
+    report = "\n".join(md_lines)
+
+    log_submission(data, report, overall)
+    await send_email(report)
+
+    return report
+
+
+async def send_email(report: str):
+    host = os.getenv("SMTP_HOST")
+    user = os.getenv("SMTP_USER")
+    pwd = os.getenv("SMTP_PASS")
+    from_addr = os.getenv("FROM_EMAIL")
+    to_addr = os.getenv("FROM_EMAIL")
+
+    if not all([host, user, pwd, from_addr]):
+        return
+
+    msg = EmailMessage()
+    msg["Subject"] = "GB1 Risk Analysis Report"
+    msg["From"] = from_addr
+    msg["To"] = to_addr
+    msg.set_content(report)
+
+    def run():
+        with smtplib.SMTP(host) as s:
+            s.starttls()
+            s.login(user, pwd)
+            s.send_message(msg)
+
+    await asyncio.to_thread(run)

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,34 @@
+import sqlite3
+import json
+from datetime import datetime
+
+DB_PATH = "app.db"
+
+def init_db():
+    conn = sqlite3.connect(DB_PATH)
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS submissions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT,
+            data TEXT,
+            report TEXT,
+            score REAL
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def log_submission(data: dict, report: str, score: float) -> None:
+    conn = sqlite3.connect(DB_PATH)
+    conn.execute(
+        "INSERT INTO submissions (timestamp, data, report, score) VALUES (?, ?, ?, ?)",
+        (datetime.utcnow().isoformat(), json.dumps(data), report, score),
+    )
+    conn.commit()
+    conn.close()
+
+
+init_db()

--- a/models/prompts.py
+++ b/models/prompts.py
@@ -1,0 +1,18 @@
+PROMPTS = {
+    "company": (
+        "Analyze the following company information for fraud and business risk. "
+        "Return JSON with keys score (0-100), rationale, and next_steps.\n\n{data}"
+    ),
+    "context": (
+        "Analyze the following deal context for potential risk. "
+        "Return JSON with keys score (0-100), rationale, and next_steps.\n\n{data}"
+    ),
+    "documents": (
+        "Analyze the following extracted document text for risk factors. "
+        "Return JSON with keys score (0-100), rationale, and next_steps.\n\n{data}"
+    ),
+    "web": (
+        "Analyze the following public data for additional risk signals. "
+        "Return JSON with keys score (0-100), rationale, and next_steps.\n\n{data}"
+    ),
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pytesseract
 Pillow
 textract
 # sqlite3 (built-in)
+markdown

--- a/templates/confirm.html
+++ b/templates/confirm.html
@@ -1,7 +1,9 @@
 {% extends "base.html" %}
 {% block title %}Confirmation{% endblock %}
 {% block content %}
-<h2 class="text-lg mb-4">Submission Complete</h2>
-<p>Your data has been submitted for analysis.</p>
-<a href="/" class="text-blue-400 underline">Return Home</a>
+<h2 class="text-lg mb-4">Ready to run analysis?</h2>
+<p>Click below to generate the AI risk report.</p>
+<form method="post" class="mt-4">
+  <button type="submit" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded">Run Analysis</button>
+</form>
 {% endblock %}

--- a/templates/report.html
+++ b/templates/report.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block title %}Risk Report{% endblock %}
+{% block content %}
+<h2 class="text-lg mb-4">Risk Analysis Report</h2>
+<div class="bg-gray-800 p-4 rounded whitespace-pre-wrap">{{ report|safe }}</div>
+<a href="/" class="text-blue-400 underline block mt-4">Return Home</a>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create analysis module with OpenAI risk scoring and email support
- store submissions in SQLite via new db module
- add modular prompt templates
- add report template and confirmation flow
- document updated workflow in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684d42f5e6c8832dadd305538fd83b34