### PR TITLE
Implement dynamic Q&A module

### DIFF
--- a/models/prompts.py
+++ b/models/prompts.py
@@ -15,4 +15,13 @@ PROMPTS = {
         "Analyze the following public data for additional risk signals. "
         "Return JSON with keys score (0-100), rationale, and next_steps.\n\n{data}"
     ),
+    "question_gen": (
+        "Based on your analysis of the following company data and context, generate a numbered list of 10 important yes/no questions for the user.\n\n{data}"
+    ),
+    "followup_gen": (
+        "Given the company information and the user's previous answers, generate a numbered list of 10 additional yes/no questions to clarify remaining risk.\n\n{data}"
+    ),
+    "qa": (
+        "Analyze the following Q&A responses for additional risk factors. Return JSON with keys score (0-100), rationale, and next_steps.\n\n{data}"
+    ),
 }

--- a/templates/confirm.html
+++ b/templates/confirm.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Confirmation{% endblock %}
 {% block content %}
-<h2 class="text-lg mb-4">Ready to run analysis?</h2>
+<h2 class="text-lg mb-4">Step 4 of 4: Ready to run analysis?</h2>
 <p>Click below to generate the AI risk report.</p>
 <form method="post" class="mt-4">
   <button type="submit" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded">Run Analysis</button>

--- a/templates/questions.html
+++ b/templates/questions.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}Questions{% endblock %}
+{% block content %}
+<h2 class="text-lg mb-4">{{ step }}</h2>
+{% if error %}<p class="text-red-500 mb-2">{{ error }}</p>{% endif %}
+<form method="post" class="space-y-6">
+{% for q in questions %}
+  <div class="mb-6 p-4 bg-gray-800 rounded-xl shadow">
+    <label class="block text-lg text-gray-200 font-semibold mb-2">{{ loop.index }}. {{ q }}</label>
+    <div class="flex gap-8 mb-2">
+      <label><input type="radio" name="q{{ loop.index }}" value="Yes" required> Yes</label>
+      <label><input type="radio" name="q{{ loop.index }}" value="No" required> No</label>
+    </div>
+    <textarea name="q{{ loop.index }}_context" rows="2" class="w-full rounded-md bg-gray-900 text-gray-200 p-2" placeholder="Optional: Add more context..."></textarea>
+  </div>
+{% endfor %}
+  <button type="submit" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded">Next</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add OpenAI prompts for question generation and follow-ups
- build helper functions to generate questions and follow-ups
- extend analysis to include Q&A responses and summary table
- create wizard steps for two rounds of questions
- show final confirmation step

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684d466ef690832dab6246fdd4bf562b