### PR TITLE
Fix missing session dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ Pillow
 # sqlite3 (built-in)
 markdown
 passlib[bcrypt]
+itsdangerous


### PR DESCRIPTION
## Summary
- add `itsdangerous` to requirements so SessionMiddleware works

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_b_684d4b0dfc28832d95a50c6ae2a2e1a7