### PR TITLE
Fix admin login by persisting DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ apache.conf.sample  Example Apache reverse proxy config
    ```bash
    docker-compose up -d --build
    ```
-   The app listens on port **57802** by default and stores uploaded files in the `uploads/` folder.
+   The app listens on port **57802** by default and stores uploaded files in the `uploads/` folder. The SQLite database file `app.db` is mapped to the project directory so data persists between commands.
 4. **Create an initial admin user**
    ```bash
    docker-compose run app python -m app.create_user admin yourpassword --role admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,4 @@ services:
       - "57802:57802"
     volumes:
       - ./uploads:/app/uploads
+      - ./app.db:/app/app.db

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,5 @@ Pillow
 # textract==1.6.4
 # sqlite3 (built-in)
 markdown
-passlib[bcrypt]
+passlib[bcrypt]>=1.7.4
 itsdangerous


### PR DESCRIPTION
## Summary
- keep SQLite db between container runs by mapping `app.db`
- document persistence in README
- ensure Passlib bcrypt plugin is new enough

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_684df2f3f300832d8852937550ff2b88