### PR TITLE
Fix OCR dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
 FROM python:3.11-slim
+
+# Install system packages required for PDF and image text extraction
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tesseract-ocr \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
+
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
+
 COPY . /app
+
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "57802"]

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ docker logs gb1-app-1 --tail=100
 - **No email delivered** &ndash; verify SMTP settings in `.env` and check container logs for errors.
 - **OpenAI errors** &ndash; ensure `OPENAI_API_KEY` is valid and your account has access to the chosen model.
 - **No AI output** &ndash; the application logs a warning if `OPENAI_API_KEY` is missing. Ensure it is set and check logs for API errors.
-- **File extraction issues** &ndash; PDF and image extraction require `pdfplumber` and `pytesseract`. In the Docker image these libraries are installed but system dependencies may be required for advanced parsing.
+- **File extraction issues** &ndash; PDF and image extraction rely on `pdfplumber` and `pytesseract`. The Docker image installs the `tesseract-ocr` package so OCR works out of the box. If running locally, ensure Tesseract is installed on your system.
 - **Changing the port** &ndash; edit `docker-compose.yml` and the `CMD` in `Dockerfile` if you need a different port.
 
 ## Contributing


### PR DESCRIPTION
## Summary
- install `tesseract-ocr` in Docker image so image OCR works
- document OCR dependency in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684e0c51a174832d9ebd507058e7370d