### PR TITLE
Handle question generation failures and improve uploads

### DIFF
--- a/app/analysis.py
+++ b/app/analysis.py
@@ -18,20 +18,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-# Fallback questions are used if the OpenAI API call fails so the UI still
-# displays something useful. These cover common due diligence topics.
-FALLBACK_QUESTIONS = [
-    "Is the company's registration current and valid?",
-    "Are any directors or owners politically exposed persons?",
-    "Is the company's address located in a high-risk jurisdiction?",
-    "Has the company or its owners been involved in litigation?",
-    "Has the company filed audited financial statements recently?",
-    "Are there any outstanding tax or regulatory issues?",
-    "Has negative media coverage been identified?",
-    "Is the beneficial ownership structure transparent?",
-    "Have any sanctions lists flagged the company or owners?",
-    "Are there undisclosed related-party transactions?",
-]
 
 import openai
 
@@ -112,10 +98,10 @@ async def generate_questions(data: dict) -> list:
             continue
         line = line.lstrip("0123456789.- ")
         questions.append(line)
-    # If the API call failed or returned nothing, fall back to generic questions
-    # so the workflow can continue.
+    # Fail fast if no questions were returned. This surfaces API issues to the
+    # caller rather than silently providing generic placeholders.
     if not questions:
-        questions = FALLBACK_QUESTIONS.copy()
+        raise RuntimeError("OpenAI did not return any questions")
 
     # Only return the first 10 items to guard against prompt injection or
     # unexpected long replies.
@@ -146,7 +132,7 @@ async def generate_followups(data: dict, answers: list) -> list:
         line = line.lstrip("0123456789.- ")
         questions.append(line)
     if not questions:
-        questions = FALLBACK_QUESTIONS.copy()
+        raise RuntimeError("OpenAI did not return follow-up questions")
     return questions[:10]
 
 

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Upload Documents{% endblock %}
 {% block content %}
+{% if error %}<p class="text-red-500 mb-2">{{ error }}</p>{% endif %}
 <form method="post" enctype="multipart/form-data" class="space-y-4">
   <div>
     <label class="block mb-1">Upload Files (PDF or images)</label>


### PR DESCRIPTION
## Summary
- remove question fallbacks and raise errors when OpenAI returns nothing
- surface extraction failures when processing user uploads
- show upload errors in the UI

## Testing
- `python -m py_compile app/main.py app/analysis.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684e667a82b0832d9afddf19832c71fc