### PR TITLE
Enable direct OpenAI vision for question generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This project was created for the enterprise client **Gene**. Gene is a self‑ho
 
 ## Features
 
- - Wizard to upload documents and answer two rounds of AI-generated yes/no questions
-- Automatic text extraction from PDF and image uploads
+- Wizard to upload documents and answer two rounds of AI-generated yes/no questions
+- Automatic text extraction from PDFs and images, with images optionally sent directly to OpenAI for vision-based question generation
 - AI generated yes/no questions to clarify risk factors (two rounds of ten questions)
 - Markdown risk report with overall score, rationale and next steps
 - Email delivery of the report (optional SMTP configuration)

--- a/models/prompts.py
+++ b/models/prompts.py
@@ -20,6 +20,9 @@ PROMPTS = {
     "question_gen": (
         "Read the following document text and generate a numbered list of 10 important yes/no questions that would help determine the riskiness of the deal and the likelihood of fraud.\n\n{data}"
     ),
+    "question_gen_image": (
+        "Read the following document image and generate a numbered list of 10 important yes/no questions that would help determine the riskiness of the deal and the likelihood of fraud."
+    ),
     "followup_gen": (
         "Given the document text and the user's previous answers, generate a numbered list of 10 additional yes/no questions that further clarify risk or uncertainties.\n\n{data}"
     ),


### PR DESCRIPTION
## Summary
- send uploaded images directly to OpenAI when generating questions
- add `question_gen_image` prompt
- document new vision-based feature in README

## Testing
- `python -m py_compile app/analysis.py models/prompts.py`
- `flake8 app/analysis.py models/prompts.py` *(fails: E402, E501 etc.)*


------
https://chatgpt.com/codex/tasks/task_b_684e6a89f9a4832db8d80320f81688d8