### PR TITLE
Fix security and session bugs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ Pillow
 markdown
 passlib[bcrypt]>=1.7.4
 itsdangerous
+bleach


### PR DESCRIPTION
## Summary
- sanitize filenames in uploads and add unique prefix
- ensure nested session updates are persisted
- handle OpenAI failure correctly in `wizard_context_post`
- sanitize markdown HTML output
- require new dependency `bleach`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68507fe998c4832dbc945876a72b4385